### PR TITLE
Avoid meta file GUID conflicts and fix package json issues

### DIFF
--- a/README.md.meta
+++ b/README.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 05190aeaf8d4c524a801a94942349c3b
+guid: f376aa0e7d9a75648a0fdbc0a1e839f0
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/Runtime.meta
+++ b/Runtime.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 60e95bfe0c17dd541afa03bef8d4cbf7
+guid: 8c8ece13e9a6bc84eb40f1423ee93bd9
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "UHTTP",
   "description": "UHTTP",
   "unity": "2022.3",
-  "unityRelease": "0b6",
+  "unityRelease": "0f1",
   "author": {
     "name": "Hamidreza Karamian"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,5 @@
   },
     "dependencies": {
     "com.unity.nuget.newtonsoft-json": "3.2.1"
-  },
-  "type": "module"
+  }
 }

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a6500ac5130969e4dab52e4f03d833d2
+guid: 7eb9a5b97a49f874596f4b83ca1729c2
 TextScriptImporter:
   externalObjects: {}
   userData: 


### PR DESCRIPTION
- Set new GUIDs for conflicting meta files.
- Remove the `type` field in the `package.json` to show the package in the `Project` tab.
- Make the package use the stable version of Unity for the minimum version.