### PR TITLE
Support appending a url to the request more safely

### DIFF
--- a/Runtime/HTTPRequestData.cs
+++ b/Runtime/HTTPRequestData.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using UHTTP.Helpers;
 using UnityEngine.Networking;
 
 namespace UHTTP
@@ -8,13 +9,7 @@ namespace UHTTP
         // URL
         public string URL { get; set; }
 
-        public void AppendUrl(string additionalUrl)
-        {
-            string slash = URL[URL.Length - 1] == '/' ? string.Empty :
-                additionalUrl[0] == '/' ? string.Empty : "/";
-
-            URL = $"{URL}{slash}{additionalUrl}";
-        }
+        public void AppendUrl(string additionalUrl) => URL = UrlUtility.Join(URL, additionalUrl);
 
         // METHOD
         public string Method { get; set; }

--- a/Runtime/HTTPRequestData.cs
+++ b/Runtime/HTTPRequestData.cs
@@ -8,6 +8,14 @@ namespace UHTTP
         // URL
         public string URL { get; set; }
 
+        public void AppendUrl(string additionalUrl)
+        {
+            string slash = URL[URL.Length - 1] == '/' ? string.Empty :
+                additionalUrl[0] == '/' ? string.Empty : "/";
+
+            URL = $"{URL}{slash}{additionalUrl}";
+        }
+
         // METHOD
         public string Method { get; set; }
 

--- a/Runtime/Utilities/UrlUtility.cs
+++ b/Runtime/Utilities/UrlUtility.cs
@@ -7,10 +7,13 @@ namespace UHTTP.Helpers
         /// </summary>
         public static string Join(string url, string additionalUrl)
         {
-            string slash = url[url.Length - 1] == '/' ? string.Empty :
-                additionalUrl[0] == '/' ? string.Empty : "/";
+            if (url[url.Length - 1] == '/')
+                url = url.Remove(url.Length - 1);
 
-            return $"{url}{slash}{additionalUrl}";
+            if (additionalUrl[0] == '/')
+                additionalUrl = additionalUrl.Substring(1);
+
+            return $"{url}/{additionalUrl}";
         }
     }
 }

--- a/Runtime/Utilities/UrlUtility.cs
+++ b/Runtime/Utilities/UrlUtility.cs
@@ -1,0 +1,16 @@
+namespace UHTTP.Helpers
+{
+    public static class UrlUtility
+    {
+        /// <summary>
+        /// Joins the urls by handling the existence or absence of the slash in the urls.
+        /// </summary>
+        public static string Join(string url, string additionalUrl)
+        {
+            string slash = url[url.Length - 1] == '/' ? string.Empty :
+                additionalUrl[0] == '/' ? string.Empty : "/";
+
+            return $"{url}{slash}{additionalUrl}";
+        }
+    }
+}

--- a/Runtime/Utilities/UrlUtility.cs.meta
+++ b/Runtime/Utilities/UrlUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6dfc39d6a457eb42ad3635bdb6ce9cf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests.meta
+++ b/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 64b7437656f64c2468bb81a788d89172
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime.meta
+++ b/Tests/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 804c49c3e8dd92341b36a009fe814d72
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/JoinUrlTest.cs
+++ b/Tests/Runtime/JoinUrlTest.cs
@@ -1,0 +1,42 @@
+using NUnit.Framework;
+using UHTTP.Helpers;
+
+namespace UHTTP.Tests
+{
+    public class JoinUrlTest
+    {
+        private const string BaseUrl = "https://sample.com";
+
+        private const string AdditionalUrl = "hello";
+
+        private static string ExpectedJoined => $"{BaseUrl}/{AdditionalUrl}";
+
+        [Test]
+        public void WithNoSlash()
+        {
+            string actualJoined = UrlUtility.Join(BaseUrl, AdditionalUrl);
+            Assert.AreEqual(ExpectedJoined, actualJoined);
+        }
+
+        [Test]
+        public void WithSlashLeft()
+        {
+            string actualJoined = UrlUtility.Join(BaseUrl + "/", AdditionalUrl);
+            Assert.AreEqual(ExpectedJoined, actualJoined);
+        }
+
+        [Test]
+        public void WithSlashRight()
+        {
+            string actualJoined = UrlUtility.Join(BaseUrl, "/" + AdditionalUrl);
+            Assert.AreEqual(ExpectedJoined, actualJoined);
+        }
+
+        [Test]
+        public void WithSlashBoth()
+        {
+            string actualJoined = UrlUtility.Join(BaseUrl + "/", "/" + AdditionalUrl);
+            Assert.AreEqual(ExpectedJoined, actualJoined);
+        }
+    }
+}

--- a/Tests/Runtime/JoinUrlTest.cs.meta
+++ b/Tests/Runtime/JoinUrlTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 10f12d93f04118942afebff5d09b5faf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/UHTTP.Tests.asmdef
+++ b/Tests/Runtime/UHTTP.Tests.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "UHTTP.Tests",
+    "rootNamespace": "UHTTP.Tests",
+    "references": [
+        "GUID:db837764b32cef843986f1f611489c42",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Tests/Runtime/UHTTP.Tests.asmdef.meta
+++ b/Tests/Runtime/UHTTP.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b5c4ad86b1225df4eac7ec968552f0b4
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Implement the `UrlUtility.Join` method.
- Implement the `HTTPRequestData.AppendUrl` method.
- Create a test for the `UrlUtility.Join` method.